### PR TITLE
Fix undefined profilePicture in layout

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -45,6 +45,14 @@ app.use(express.urlencoded({ extended: true, limit: '1mb' }));
 
 app.locals.version = version;
 
+// Ensure template variables exist even before authentication setup
+app.use((req, res, next) => {
+  res.locals.currentUser = null;
+  res.locals.role = null;
+  res.locals.profilePicture = null;
+  next();
+});
+
 if (setupNeeded) {
   app.use('/', setupRouter);
   app.use((req, res) => res.redirect('/setup'));

--- a/src/admin/views/layout.ejs
+++ b/src/admin/views/layout.ejs
@@ -120,7 +120,7 @@
         <span class="navbar-text text-muted me-3 d-none d-lg-inline">v<%= version %></span>
         <div class="dropdown">
           <a class="nav-link dropdown-toggle text-secondary d-flex align-items-center" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <% if (profilePicture) { %>
+            <% if (typeof profilePicture !== 'undefined' && profilePicture) { %>
               <img src="<%= profilePicture %>" alt="avatar" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
             <% } else { %>
               <i class="bi bi-person-circle me-1 fs-5"></i>


### PR DESCRIPTION
## Summary
- add default values for layout variables in admin panel
- handle missing `profilePicture` in layout template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684015b10b388322af1e51ef89890474